### PR TITLE
Fixed file-naming problems

### DIFF
--- a/app/home/down-git.js
+++ b/app/home/down-git.js
@@ -23,7 +23,7 @@ downGitModule.factory('downGitService', [
             info.repository = splitPath[2];
             info.branch = splitPath[4];
 
-            info.rootName = splitPath[splitPath.length-1];
+            info.rootName = decodeURI(splitPath[splitPath.length-1]);
             if(!!splitPath[4]){
                 info.resPath = repoPath.substring(
                     repoPath.indexOf(splitPath[4])+splitPath[4].length+1


### PR DESCRIPTION
Let's say you are downloading https://github.com/besnoi/pyApps/tree/main/src/Snipping%20Tool, with `%20` representing whitespace then in present version the downloaded file will as well retain the `%20` instead of converting it back to whitespace

This is not aesthetically and even practically pleasing cause the app has de facto renamed the original file, hence this PR 😃